### PR TITLE
fix: remove reduntant empty line to avoid build errors

### DIFF
--- a/integrated-models/Human-GEM/dataOverlay/transcriptomics/index.tsv
+++ b/integrated-models/Human-GEM/dataOverlay/transcriptomics/index.tsv
@@ -1,3 +1,2 @@
 filename	name	link	lastUpdated
 hpaRna.tsv	Human Protein Atlas 20.1	https://www.proteinatlas.org/about/releases#20.1	2021-09-24
-


### PR DESCRIPTION
This PR fixes the error `Error: ENOENT: no such file or directory, open '../data-files/integrated-models/Human-GEM/dataOverlay/transcriptomics/undefined'` when running `build-stack`