### PR TITLE
Feat: collect release data for GEMs repository 

### DIFF
--- a/integrated-models/Fruitfly-GEM/gemRepository.json
+++ b/integrated-models/Fruitfly-GEM/gemRepository.json
@@ -1,7 +1,12 @@
 [
   {
     "id": "Fruitfly-GEM-1.0.0",
-    "externalParentId": [],
+    "externalParentId": [
+      {
+        "id": "Human-GEM-1.5.0",
+        "citLink": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template"
+      }
+    ],
     "releaseDate": "2021-01-17",
     "releaseLink": "https://github.com/SysBioChalmers/Fruitfly-GEM/releases/tag/v1.0.0",
     "PMID": "34282017",

--- a/integrated-models/Fruitfly-GEM/gemRepository.json
+++ b/integrated-models/Fruitfly-GEM/gemRepository.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "Fruitfly-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Fruitfly-GEM/releases/tag/v1.0.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Fruitfly-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Fruitfly-GEM/releases/tag/v1.1.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Fruitfly-GEM/gemRepository.json
+++ b/integrated-models/Fruitfly-GEM/gemRepository.json
@@ -21,5 +21,14 @@
     "PMID": "34282017",
     "count": {},
     "validation": {}
+  },
+  {
+    "id": "Fruitfly-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2022-05-03",
+    "releaseLink": "https://github.com/SysBioChalmers/Fruitfly-GEM/releases/tag/v1.2.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
   }
 ]

--- a/integrated-models/Human-GEM/gemRepository.json
+++ b/integrated-models/Human-GEM/gemRepository.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": "Human-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2019-03-12",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.0.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.0.1",
+    "externalParentId": [],
+    "releaseDate": "2019-04-03",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.0.1",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.0.2",
+    "externalParentId": [],
+    "releaseDate": "2019-04-19",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.0.2",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.0.3",
+    "externalParentId": [],
+    "releaseDate": "2019-05-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.0.3",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2019-06-13",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.1.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.1.1",
+    "externalParentId": [],
+    "releaseDate": "2019-09-26",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.1.1",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.1.2",
+    "externalParentId": [],
+    "releaseDate": "2019-10-04",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.1.2",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.1.3",
+    "externalParentId": [],
+    "releaseDate": "2019-10-21",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.1.3",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2019-11-25",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.2.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.2.1",
+    "externalParentId": [],
+    "releaseDate": "2019-12-16",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.2.1",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.3.0",
+    "externalParentId": [],
+    "releaseDate": "2019-12-19",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.3.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.3.1",
+    "externalParentId": [],
+    "releaseDate": "2020-03-27",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.3.1",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.3.2",
+    "externalParentId": [],
+    "releaseDate": "2020-04-25",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.3.2",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.4.0",
+    "externalParentId": [],
+    "releaseDate": "2020-06-12",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.4.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.4.1",
+    "externalParentId": [],
+    "releaseDate": "2020-07-29",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.4.1",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.5.0",
+    "externalParentId": [],
+    "releaseDate": "2020-10-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.5.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.6.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-25",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.6.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.7.0",
+    "externalParentId": [],
+    "releaseDate": "2021-04-20",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.7.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.8.0",
+    "externalParentId": [],
+    "releaseDate": "2021-06-23",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.8.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.9.0",
+    "externalParentId": [],
+    "releaseDate": "2021-08-12",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.9.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.10.0",
+    "externalParentId": [],
+    "releaseDate": "2021-09-14",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.10.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Human-GEM-1.11.0",
+    "externalParentId": [],
+    "releaseDate": "2022-02-07",
+    "releaseLink": "https://github.com/SysBioChalmers/Human-GEM/releases/tag/v1.11.0",
+    "PMID": "32209698",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Mouse-GEM/gemRepository.json
+++ b/integrated-models/Mouse-GEM/gemRepository.json
@@ -1,7 +1,12 @@
 [
   {
     "id": "Mouse-GEM-1.0.0",
-    "externalParentId": [],
+    "externalParentId": [
+      {
+        "id": "Human-GEM-1.5.0",
+        "citLink": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template"
+      }
+    ],
     "releaseDate": "2020-10-24",
     "releaseLink": "https://github.com/SysBioChalmers/Mouse-GEM/releases/tag/v1.0.0",
     "PMID": "34282017",

--- a/integrated-models/Mouse-GEM/gemRepository.json
+++ b/integrated-models/Mouse-GEM/gemRepository.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "Mouse-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2020-10-24",
+    "releaseLink": "https://github.com/SysBioChalmers/Mouse-GEM/releases/tag/v1.0.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Mouse-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-15",
+    "releaseLink": "https://github.com/SysBioChalmers/Mouse-GEM/releases/tag/v1.1.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Mouse-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Mouse-GEM/releases/tag/v1.2.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Mouse-GEM-1.3.0",
+    "externalParentId": [],
+    "releaseDate": "2022-04-05",
+    "releaseLink": "https://github.com/SysBioChalmers/Mouse-GEM/releases/tag/v1.3.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Rat-GEM/gemRepository.json
+++ b/integrated-models/Rat-GEM/gemRepository.json
@@ -30,5 +30,14 @@
     "PMID": "34282017",
     "count": {},
     "validation": {}
+  },
+  {
+    "id": "Rat-GEM-1.3.0",
+    "externalParentId": [],
+    "releaseDate": "2022-05-03",
+    "releaseLink": "https://github.com/SysBioChalmers/Rat-GEM/releases/tag/v1.3.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
   }
 ]

--- a/integrated-models/Rat-GEM/gemRepository.json
+++ b/integrated-models/Rat-GEM/gemRepository.json
@@ -1,7 +1,12 @@
 [
   {
     "id": "Rat-GEM-1.0.0",
-    "externalParentId": [],
+    "externalParentId": [
+      {
+        "id": "Human-GEM-1.5.0",
+        "citLink": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template"
+      }
+    ],
     "releaseDate": "2020-10-24",
     "releaseLink": "https://github.com/SysBioChalmers/Rat-GEM/releases/tag/v1.0.0",
     "PMID": "34282017",

--- a/integrated-models/Rat-GEM/gemRepository.json
+++ b/integrated-models/Rat-GEM/gemRepository.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "Rat-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2020-10-24",
+    "releaseLink": "https://github.com/SysBioChalmers/Rat-GEM/releases/tag/v1.0.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Rat-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-15",
+    "releaseLink": "https://github.com/SysBioChalmers/Rat-GEM/releases/tag/v1.1.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Rat-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Rat-GEM/releases/tag/v1.2.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Worm-GEM/gemRepository.json
+++ b/integrated-models/Worm-GEM/gemRepository.json
@@ -30,5 +30,14 @@
     "PMID": "34282017",
     "count": {},
     "validation": {}
+  },
+  {
+    "id": "Worm-GEM-1.3.0",
+    "externalParentId": [],
+    "releaseDate": "2022-05-03",
+    "releaseLink": "https://github.com/SysBioChalmers/Worm-GEM/releases/tag/v1.3.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
   }
 ]

--- a/integrated-models/Worm-GEM/gemRepository.json
+++ b/integrated-models/Worm-GEM/gemRepository.json
@@ -1,7 +1,12 @@
 [
   {
     "id": "Worm-GEM-1.0.0",
-    "externalParentId": [],
+    "externalParentId": [
+      {
+        "id": "Human-GEM-1.5.0",
+        "citLink": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template"
+      }
+    ],
     "releaseDate": "2021-01-17",
     "releaseLink": "https://github.com/SysBioChalmers/Worm-GEM/releases/tag/v1.0.0",
     "PMID": "34282017",

--- a/integrated-models/Worm-GEM/gemRepository.json
+++ b/integrated-models/Worm-GEM/gemRepository.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "Worm-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Worm-GEM/releases/tag/v1.0.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Worm-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2021-05-30",
+    "releaseLink": "https://github.com/SysBioChalmers/Worm-GEM/releases/tag/v1.1.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Worm-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Worm-GEM/releases/tag/v1.2.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Yeast-GEM/gemRepository.json
+++ b/integrated-models/Yeast-GEM/gemRepository.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": "Yeast-GEM-7.6.0",
+    "externalParentId": [],
+    "releaseDate": "2018-06-27",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.6.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-7.7.0",
+    "externalParentId": [],
+    "releaseDate": "2018-06-27",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.7.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-7.8.0",
+    "externalParentId": [],
+    "releaseDate": "2018-01-18",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.8.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-7.8.1",
+    "externalParentId": [],
+    "releaseDate": "2018-01-25",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.8.1",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-7.8.2",
+    "externalParentId": [],
+    "releaseDate": "2018-01-30",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.8.2",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-7.8.3",
+    "externalParentId": [],
+    "releaseDate": "2018-02-28",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v7.8.3",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.0.0",
+    "externalParentId": [],
+    "releaseDate": "2018-03-30",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.0.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.0.1",
+    "externalParentId": [],
+    "releaseDate": "2018-04-16",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.0.1",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.0.2",
+    "externalParentId": [],
+    "releaseDate": "2018-05-14",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.0.2",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.1.0",
+    "externalParentId": [],
+    "releaseDate": "2018-05-30",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.1.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.1.1",
+    "externalParentId": [],
+    "releaseDate": "2018-06-10",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.1.1",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.1.2",
+    "externalParentId": [],
+    "releaseDate": "2018-06-27",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.1.2",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.1.3",
+    "externalParentId": [],
+    "releaseDate": "2018-07-16",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.1.3",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.2.0",
+    "externalParentId": [],
+    "releaseDate": "2018-08-08",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.2.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.0",
+    "externalParentId": [],
+    "releaseDate": "2018-09-06",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.1",
+    "externalParentId": [],
+    "releaseDate": "2018-09-28",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.1",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.2",
+    "externalParentId": [],
+    "releaseDate": "2018-11-22",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.2",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.3",
+    "externalParentId": [],
+    "releaseDate": "2018-12-06",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.3",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.4",
+    "externalParentId": [],
+    "releaseDate": "2019-07-28",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.4",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.3.5",
+    "externalParentId": [],
+    "releaseDate": "2020-04-02",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.3.5",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.4.0",
+    "externalParentId": [],
+    "releaseDate": "2020-06-15",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.4.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.4.1",
+    "externalParentId": [],
+    "releaseDate": "2020-07-20",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.4.1",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.4.2",
+    "externalParentId": [],
+    "releaseDate": "2020-09-23",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.4.2",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Yeast-GEM-8.5.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-02",
+    "releaseLink": "https://github.com/SysBioChalmers/yeast-GEM/releases/tag/v8.5.0",
+    "PMID": "31395883",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Zebrafish-GEM/gemRepository.json
+++ b/integrated-models/Zebrafish-GEM/gemRepository.json
@@ -1,7 +1,12 @@
 [
   {
     "id": "Zebrafish-GEM-1.0.0",
-    "externalParentId": [],
+    "externalParentId": [
+      {
+        "id": "Human-GEM-1.5.0",
+        "citLink": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template"
+      }
+    ],
     "releaseDate": "2021-01-17",
     "releaseLink": "https://github.com/SysBioChalmers/Zebrafish-GEM/releases/tag/v1.0.0",
     "PMID": "34282017",

--- a/integrated-models/Zebrafish-GEM/gemRepository.json
+++ b/integrated-models/Zebrafish-GEM/gemRepository.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "Zebrafish-GEM-1.0.0",
+    "externalParentId": [],
+    "releaseDate": "2021-01-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Zebrafish-GEM/releases/tag/v1.0.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  },
+  {
+    "id": "Zebrafish-GEM-1.1.0",
+    "externalParentId": [],
+    "releaseDate": "2021-07-17",
+    "releaseLink": "https://github.com/SysBioChalmers/Zebrafish-GEM/releases/tag/v1.1.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
+  }
+]

--- a/integrated-models/Zebrafish-GEM/gemRepository.json
+++ b/integrated-models/Zebrafish-GEM/gemRepository.json
@@ -21,5 +21,14 @@
     "PMID": "34282017",
     "count": {},
     "validation": {}
+  },
+  {
+    "id": "Zebrafish-GEM-1.2.0",
+    "externalParentId": [],
+    "releaseDate": "2022-05-03",
+    "releaseLink": "https://github.com/SysBioChalmers/Zebrafish-GEM/releases/tag/v1.2.0",
+    "PMID": "34282017",
+    "count": {},
+    "validation": {}
   }
 ]

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -8,6 +8,18 @@ import json
 import argparse
 from github import Github
 
+# define data for externalParentId
+EXT_PARENT_ID = {
+        }
+
+# define PMID for each specific release (if there is any)
+RELEASE_PMID_DICT = {
+        }
+
+# define PMID for each GEM
+GEM_PMID_DICT = {
+        }
+
 
 def writefile(content, outfile, mode='w', is_flush=False):
     """Write text to file"""
@@ -20,24 +32,51 @@ def writefile(content, outfile, mode='w', is_flush=False):
     except IOError:
         print(f"Failed to write to {outfile}", file=sys.stderr)
 
+def get_count(repo_name, api_token):
+    """Get count for genes, reactions and metabolites"""
+    # To be implemented
+    return {}
+
+
+def get_validation(repo_name, api_token):
+    """Get quality score for the model"""
+    # To be implemented
+    return {}
+
 
 def get_release_data(repo_name, git_api):
     """Get release data from Github"""
     repo = git_api.get_repo(repo_name)
     releases = repo.get_releases()
     gem_name = os.path.basename(repo_name)
-    gem_data = {}
+    gem_data_list = []
     for rel in releases:
+        if rel.prerelease:  # ignore pre releases
+            continue
         version = rel.tag_name.lstrip('v')
-        gem_data[version] = {}
-        gem_data[version]['title'] = rel.title
-        gem_data[version]['id'] = f"{gem_name}-{version}"
-        gem_data[version]['date'] = rel.published_at.strftime("%Y-%m-%d")
-        gem_data[version]['tag_name'] = rel.tag_name
-        gem_data[version]['link'] = rel.html_url
-        gem_data[version]['version'] = rel.tag_name.lstrip('v')
-        gem_data[version]['prerelease'] = rel.prerelease
-    return gem_data
+        li = version.split('-')
+        if len(li) > 1:  # ignore alpha or beta releases
+            continue
+        gem_data = {}
+        rel_id = f"{gem_name}-{version}"
+        gem_data['id'] = rel_id
+        if rel_id in EXT_PARENT_ID:
+            gem_data['externalParentId'] = EXT_PARENT_ID[rel_id]
+        else:
+            gem_data['externalParentId'] = []
+        gem_data['releaseDate'] = rel.published_at.strftime("%Y-%m-%d")
+        gem_data['releaseLink'] = rel.html_url
+        if rel_id in RELEASE_PMID_DICT:
+            gem_data['PMID'] = RELEASE_PMID_DICT[rel_id]
+        elif gem_name in GEM_PMID_DICT:
+            gem_data['PMID'] = GEM_PMID_DICT[gem_name]
+        else:
+            gem_data['PMID'] = ''
+        gem_data['count'] = get_count(repo_name, git_api)
+        gem_data['validation'] = get_validation(repo_name, git_api)
+        gem_data_list.append(gem_data)
+
+    return gem_data_list
 
 
 def get_integrated_gems_list(repo_name, git_api):
@@ -55,15 +94,13 @@ def generate_data(git_api, basedir, is_dryrun):
     """Fetch data from Github and output the result in JSON format"""
     owner = "SysBioChalmers"
     gems_list = get_integrated_gems_list("MetabolicAtlas/data-files", git_api)
-    all_data = {}
     for gem_name in gems_list:
         repo_name = f"{owner}/{gem_name}"
         gem_release_data = get_release_data(repo_name, git_api)
-        all_data[gem_name] = gem_release_data
         outfile = os.path.join(basedir, 'integrated-models', gem_name,
                                'gemRepository.json')
         if not is_dryrun:
-            writefile(json.dumps(all_data, indent=2), outfile)
+            writefile(json.dumps(gem_release_data, indent=2), outfile)
             msg = f"Result file output to {outfile}"
         else:
             msg = f"DryRun: result file will be output to {outfile}"

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -3,20 +3,27 @@
     Fetch release data from Github and output the result in JSON format
 """
 import os
+import sys
 import json
+import argparse
 from github import Github
 
-try:
-    api_token = os.environ['GH_TOKEN']
-except KeyError:
-    api_token = None
 
-g = Github(api_token)
+def writefile(content, outfile, mode='w', is_flush=False):
+    """Write text to file"""
+    try:
+        fpout = open(outfile, mode)
+        fpout.write(content)
+        if is_flush:
+            fpout.flush()
+        fpout.close()
+    except IOError:
+        print(f"Failed to write to {outfile}", file=sys.stderr)
 
 
-def get_release_data(repo_name):
+def get_release_data(repo_name, git_api):
     """Get release data from Github"""
-    repo = g.get_repo(repo_name)
+    repo = git_api.get_repo(repo_name)
     releases = repo.get_releases()
     gem_name = os.path.basename(repo_name)
     gem_data = {}
@@ -33,9 +40,9 @@ def get_release_data(repo_name):
     return gem_data
 
 
-def get_integrated_gems_list(repo_name):
+def get_integrated_gems_list(repo_name, git_api):
     """Get the list of integrated GEMS from Github"""
-    repo = g.get_repo(repo_name)
+    repo = git_api.get_repo(repo_name)
     file_content = repo.get_contents("integrated-models/integratedModels.json")
     data = json.loads(file_content.decoded_content.decode())
     gems_list = []
@@ -44,17 +51,49 @@ def get_integrated_gems_list(repo_name):
     return gems_list
 
 
-def generate_data():
+def generate_data(git_api, basedir, is_dryrun):
     """Fetch data from Github and output the result in JSON format"""
     owner = "SysBioChalmers"
-    gems_list = get_integrated_gems_list("MetabolicAtlas/data-files")
+    gems_list = get_integrated_gems_list("MetabolicAtlas/data-files", git_api)
     all_data = {}
     for gem_name in gems_list:
         repo_name = f"{owner}/{gem_name}"
-        gem_release_data = get_release_data(repo_name)
+        gem_release_data = get_release_data(repo_name, git_api)
         all_data[gem_name] = gem_release_data
-    print(json.dumps(all_data, indent=2))
+        outfile = os.path.join(basedir, 'integrated-models', gem_name,
+                               'gemRepository.json')
+        if not is_dryrun:
+            writefile(json.dumps(all_data, indent=2), outfile)
+            msg = f"Result file output to {outfile}"
+        else:
+            msg = f"DryRun: result file will be output to {outfile}"
+        print(msg)
+
+
+def main():
+    """main procedure"""
+    parser = argparse.ArgumentParser(
+        description='Generate data for GEMs repository',
+        formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+    parser.add_argument('-d', '--dry', dest='is_dryrun', default=False,
+                        help='do not save output to file',
+                        action='store_true')
+
+    args = parser.parse_args()
+    is_dryrun = args.is_dryrun
+
+    try:
+        api_token = os.environ['GH_TOKEN']
+    except KeyError:
+        api_token = None
+
+    git_api = Github(api_token)
+    rundir = os.path.dirname(sys.argv[0])
+    basedir = os.path.realpath(os.path.join(rundir, os.pardir))
+
+    generate_data(git_api, basedir, is_dryrun)
 
 
 if __name__ == "__main__":
-    generate_data()
+    main()

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -76,6 +76,9 @@ def get_release_data(repo_name, git_api):
         gem_data['validation'] = get_validation(repo_name, git_api)
         gem_data_list.append(gem_data)
 
+    # sort the releases in the ascending order
+    gem_data_list = gem_data_list[::-1]
+
     return gem_data_list
 
 

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -18,6 +18,13 @@ RELEASE_PMID_DICT = {
 
 # define PMID for each GEM
 GEM_PMID_DICT = {
+        'Yeast-GEM': '31395883',
+        'Human-GEM': '32209698',
+        'Mouse-GEM': '34282017',
+        'Rat-GEM': '34282017',
+        'Zebrafish-GEM': '34282017',
+        'Fruitfly-GEM': '34282017',
+        'Worm-GEM': '34282017',
         }
 
 
@@ -31,6 +38,7 @@ def writefile(content, outfile, mode='w', is_flush=False):
         fpout.close()
     except IOError:
         print(f"Failed to write to {outfile}", file=sys.stderr)
+
 
 def get_count(repo_name, api_token):
     """Get count for genes, reactions and metabolites"""

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -9,7 +9,38 @@ import argparse
 from github import Github
 
 # define data for externalParentId
+CITLINK_1 = 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8325244/#:~:text=In%20this%20pipeline%2C%20the%20open%2Dcurated%20generic%20human%20GEM%2C%20Human1%20(11)%2C%20was%20used%20as%20a%20template'
 EXT_PARENT_ID = {
+        'Mouse-GEM-1.0.0': [
+            {
+                'id': 'Human-GEM-1.5.0',
+                'citLink': CITLINK_1
+                }
+            ],
+        'Rat-GEM-1.0.0': [
+            {
+                'id': 'Human-GEM-1.5.0',
+                'citLink': CITLINK_1
+                }
+            ],
+        'Zebrafish-GEM-1.0.0': [
+            {
+                'id': 'Human-GEM-1.5.0',
+                'citLink': CITLINK_1
+                }
+            ],
+        'Fruitfly-GEM-1.0.0': [
+            {
+                'id': 'Human-GEM-1.5.0',
+                'citLink': CITLINK_1
+                }
+            ],
+        'Worm-GEM-1.0.0': [
+            {
+                'id': 'Human-GEM-1.5.0',
+                'citLink': CITLINK_1
+                }
+            ],
         }
 
 # define PMID for each specific release (if there is any)

--- a/utils/fetch_release_data.py
+++ b/utils/fetch_release_data.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Description:
+    Fetch release data from Github and output the result in JSON format
+"""
+import os
+import json
+from github import Github
+
+try:
+    api_token = os.environ['GH_TOKEN']
+except KeyError:
+    api_token = None
+
+g = Github(api_token)
+
+
+def get_release_data(repo_name):
+    """Get release data from Github"""
+    repo = g.get_repo(repo_name)
+    releases = repo.get_releases()
+    gem_name = os.path.basename(repo_name)
+    gem_data = {}
+    for rel in releases:
+        version = rel.tag_name.lstrip('v')
+        gem_data[version] = {}
+        gem_data[version]['title'] = rel.title
+        gem_data[version]['id'] = f"{gem_name}-{version}"
+        gem_data[version]['date'] = rel.published_at.strftime("%Y-%m-%d")
+        gem_data[version]['tag_name'] = rel.tag_name
+        gem_data[version]['link'] = rel.html_url
+        gem_data[version]['version'] = rel.tag_name.lstrip('v')
+        gem_data[version]['prerelease'] = rel.prerelease
+    return gem_data
+
+
+def get_integrated_gems_list(repo_name):
+    """Get the list of integrated GEMS from Github"""
+    repo = g.get_repo(repo_name)
+    file_content = repo.get_contents("integrated-models/integratedModels.json")
+    data = json.loads(file_content.decoded_content.decode())
+    gems_list = []
+    for item in data:
+        gems_list.append(item['short_name'])
+    return gems_list
+
+
+def generate_data():
+    """Fetch data from Github and output the result in JSON format"""
+    owner = "SysBioChalmers"
+    gems_list = get_integrated_gems_list("MetabolicAtlas/data-files")
+    all_data = {}
+    for gem_name in gems_list:
+        repo_name = f"{owner}/{gem_name}"
+        gem_release_data = get_release_data(repo_name)
+        all_data[gem_name] = gem_release_data
+    print(json.dumps(all_data, indent=2))
+
+
+if __name__ == "__main__":
+    generate_data()

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,5 @@
+PyGithub==1.55
+pandas==1.3.5
+numpy==1.21.5
+PyYAML==6.0
+matplotlib==3.0.3


### PR DESCRIPTION
This PR closes [#954](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/metabolicatlas/954)

**Changes made**
- A script `utils/fetch_release_data.py` is added
- The JSON files `gemRepository.json ` are added to their respective folders.
- [The documentation](https://github.com/MetabolicAtlas/docs/wiki/GEMs-repository-data) for description of the GEMs repository data and how to generate it is added in the wiki.

**Additional notes**
externalParentId, count and validation are not added in the PR. If someone has a complete view of the externalParentId info, I can add it to this PR as well. Obtaining the values for the count and validation will be addressed in new issues. 