### PR TITLE
feat: add a flag to show all updatable models

### DIFF
--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,6 @@
 PyGithub==1.55
 pandas==1.3.5
 numpy==1.21.5
+packaging==21.3
 PyYAML==6.0
 matplotlib==3.0.3


### PR DESCRIPTION
This PR is related to one of the acceptance criteria of the issue [#970](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/metabolicatlas/970)

**Test**
Run the command 
```
./utils/fetch_release_data.py -u
```
And it will output something like below
```
Yeast-GEM can be updated: 8.4.2 => 8.6.0
Human-GEM can be updated: 1.10.0 => 1.11.0
Mouse-GEM can be updated: 1.2.0 => 1.3.0
Rat-GEM can be updated: 1.2.0 => 1.3.0
Zebrafish-GEM can be updated: 1.1.0 => 1.2.0
Fruitfly-GEM can be updated: 1.1.0 => 1.2.0
Worm-GEM can be updated: 1.1.0 => 1.3.0
```