### PR TITLE
feat: add new dataset for map overlay

### DIFF
--- a/DATA_OVERLAY.md
+++ b/DATA_OVERLAY.md
@@ -2,7 +2,7 @@
 
 In [Metabolic Atlas](https://github.com/MetabolicAtlas/MetabolicAtlas), the visualization of components, such as in the Map Viewer, can be customized using [Data overlay](https://metabolicatlas.org/documentation#Data-overlay).
 
-For each integrated model, Data overlay allows for multiple data types, such as Transcriptomics and Metabolomics. Each data type allows for multiple data sources, as well as the option for the user to upload and use their custom data on the fly. Each data source can contain multiple datasets, which contain values to be used to customize the visualization.
+For each integrated model, Data overlay allows for multiple overlay object types such as Genes, Reactions and Metabolites. Each overlay object type allows for multiple data sources, as well as the option for the user to upload and use their custom data on the fly. Each data source can contain multiple datasets, which contain values to be used to customize the visualization.
 
 ## Data source file requirements
 
@@ -20,6 +20,7 @@ For each integrated model, Data overlay allows for multiple data types, such as 
 | --------------- | -------------- | ------------- |
 | ENSG00000000419 | 0.456          | 0.697         |
 | ENSG00000000938 | 0.291          | 0.57          |
+
 
 ### The 0-1 range
 
@@ -57,13 +58,19 @@ As shown by the figure below, the histogram of scaled data is more evenly distri
 
 ![Histogram of HPA scaled data](./assets/img/hpaRNA-TPM-scaleddata-histogram.png)
 
+
+### Linear distribution of label colors
+
+When a dataset contains labels a simplay way to assign values is to split the range `[0,1]` in `N` parts with a fixed step size of `1/N`, where `N` is the number of labels. Then for each entry calculate `scaled_data = indexOf(label)/N`, where `label` is the label of the entry.
+
+
 ## Folder structure and naming conventions
 
 All data source files should be stored in the [data-files repo](https://github.com/MetabolicAtlas/data-files).
 
 Under each folder in [`/integrated-models`](https://github.com/MetabolicAtlas/data-files/tree/main/integrated-models), there should be a `dataOverlay` folder, for example: `data-files/integrated-models/Human-GEM/dataOverlay`. If not, it means the model currently does not have any data sources for data overlay and the `dataOverlay` folder should be added.
 
-Inside of the `dataOverlay` folder, there could be one or more folders, where the name of each folder should be the data type. Currently, the types `transcriptomics` and `metabolomics` are supported.
+Inside of the `dataOverlay` folder, there could be one or more folders, where the name of each folder should be the overlay object type. Currently, the types `gene`, `metabolite` and `reaction` are supported.
 
 Inside of a data type folder, there could be one or more data source files, such as `hpa.tsv`. There should also be an `index.tsv` file, which contains the metadata for all of the data sources in this folder. When adding a new data source, a new row should be added to the `index.tsv` file with the following values:
 

--- a/DATA_OVERLAY.md
+++ b/DATA_OVERLAY.md
@@ -61,7 +61,7 @@ As shown by the figure below, the histogram of scaled data is more evenly distri
 
 ### Linear distribution of label colors
 
-When a dataset contains labels a simplay way to assign values is to split the range `[0,1]` in `N` parts with a fixed step size of `1/N`, where `N` is the number of labels. Then for each entry calculate `scaled_data = indexOf(label)/N`, where `label` is the label of the entry.
+When a dataset contains labels a simple way to assign values is to split the range `[0,1]` in `N` parts with a fixed step size of `1/N`, where `N` is the number of labels. Then for each entry calculate `scaled_data = indexOf(label)/N`, where `label` is the label of the entry.
 
 
 ## Folder structure and naming conventions

--- a/integrated-models/Yeast-GEM/dataOverlay/gene/index.tsv
+++ b/integrated-models/Yeast-GEM/dataOverlay/gene/index.tsv
@@ -1,0 +1,2 @@
+filename	name	link	lastUpdated
+target-matrix.tsv	Predicted metabolic engineering targets for increased production	https://www.biorxiv.org/content/10.1101/2023.01.31.526512v1	2023-04-05

--- a/integrated-models/Yeast-GEM/dataOverlay/gene/index.tsv
+++ b/integrated-models/Yeast-GEM/dataOverlay/gene/index.tsv
@@ -1,2 +1,2 @@
 filename	name	link	lastUpdated
-target-matrix.tsv	Predicted metabolic engineering targets for increased production	https://www.biorxiv.org/content/10.1101/2023.01.31.526512v1	2023-04-05
+target-matrix.tsv	Cell factory targets	https://www.biorxiv.org/content/10.1101/2023.01.31.526512v1	2023-04-05

--- a/integrated-models/Yeast-GEM/dataOverlay/gene/target-matrix.tsv
+++ b/integrated-models/Yeast-GEM/dataOverlay/gene/target-matrix.tsv
@@ -1,0 +1,1149 @@
+id	acetate	adipic_acid	alanine	amorphadiene	ara	arginine	artemisinic_acid	asparagine	aspartate	astaxanthin	beta_amyrin	beta_carotene	beta_ionone	betaxanthin	caffeic_acid	catechin	choline	cinnamate	cinnamoyltropine	cis_muconate	citrate	citrulline	coumaric_acid	cysteine	dha	docosanol	epa	ergosterol	ergothioneine	farnesene	ffas	fumaric_acid	genistein	geraniol	glutamate	glutamine	glutathione	glycerol	glycine	glycolate	glycyrrhetinic_acid	hexanoate	histidine	homoserine	hydroxymandelic_acid	hypoxanthine	isobutanol	isoleucine	itaconic_acid	kaempferol	l_pac	lactate	laurate	leucine	limonene	linalool	lupeol	lycopene	lysine	malate	mandelic_acid	methionine	methylbutanol	miltiradiene	n_butanol	naringenin	nicotianamine	nootkatone	oleanolate	oleate	ornithine	oxoglutarate	palmitoleate	patchoulol	phenylalanine	phenylethanol	proline	protopanaxadiol	psilocybin	putrescine	pyruvate	quercetin	resveratrol	rosmarinic_acid	rrbutanediol	s_reticuline	salidroside	santalene	serine	spermine	squalene	succinate	taxadien_acetate	threonine	triacylglycerol	tryptophan	tyrosine	tyrosol	valencene	valine	vanillin_glucoside	xanthine
+Q0045																																																																																	1.00																					
+Q0080																																														1.00																																																								
+Q0085																																														1.00																																																								
+Q0105																																														1.00																																																								
+Q0130																																														1.00																																																								
+Q0250																																																																																	1.00																					
+Q0275																																																																																	1.00																					
+YAL012W																																																																																							0.00											0.00				
+YAL022C																																																																																																						
+YAL023C																																																																																																						
+YAL038W				1.00		1.00	1.00	1.00			1.00						1.00					1.00	1.00							1.00	1.00	1.00		1.00		1.00	1.00					1.00		1.00					1.00		1.00	1.00		1.00	1.00				1.00	1.00			1.00		1.00				1.00	1.00			1.00				1.00			1.00	1.00			1.00	1.00			1.00			1.00			1.00								
+YAL044C																																							0.00															0.00					0.00				0.40																																							
+YAL054C	0.00																																																																																																					
+YAL060W																																																																																																						
+YAL062W																																								0.40																																															0.00											0.00				
+YAR015W																																														1.00																																																								1.00
+YAR035W																																																																																																						
+YAR071W																																																																																																						
+YBL011W																																																																																																						
+YBL013W																																																																																																						
+YBL015W																																																																																																						
+YBL030C																																																																																																						
+YBL033C									0.40																																																																																													
+YBL039C																																																																																																						
+YBL042C																																																																																																						
+YBL045C																																														1.00																																																								
+YBL064C																																																																																																						
+YBL068W																																																																																																						
+YBL076C																																																																																																						
+YBL098W					1.00																				1.00		1.00																																																																											
+YBL099W																																																																																																						
+YBR002C																																																																																																						
+YBR003W																																																																																																						
+YBR004C																																																																																																						
+YBR006W																																																																																																						
+YBR011C																																																																																																						
+YBR018C																																																																																																						
+YBR019C																																																																																																						
+YBR020W																																																																																																						
+YBR021W																																																																																																						
+YBR023C																																																																																																						
+YBR026C																																																																																																						
+YBR029C			0.40																																		0.40		0.40								0.40																																											0.40		0.40								0.40		
+YBR034C																																																																																																						
+YBR035C																																																																																																						
+YBR036C																																																																																																						
+YBR038W																																																																																																						
+YBR039W																																														1.00																																																								
+YBR041W																																																																																																						
+YBR042C																																																																																																						
+YBR058C-A																																																																																																						
+YBR068C																																																																																																						
+YBR069C																																																																																																						
+YBR084W																																																																																																						
+YBR085W																																																																																																						
+YBR092C																																																																																																						
+YBR093C																																																																																																						
+YBR097W																																																																																																						
+YBR110W																																																																																																						
+YBR115C																																																											1.00																												0.00											0.00				
+YBR117C																							0.00																																										0.00																			0.00						0.00												
+YBR121C																																																																																																						
+YBR126C																																																																																																						
+YBR127C																																																																																																						
+YBR132C																																																																																																						
+YBR145W																																																																																																						
+YBR149W																																																																																																						
+YBR153W																																																																																																						
+YBR159W																																																																																																						
+YBR161W																																																																																																						
+YBR166C																							1.00																						1.00																																						1.00	1.00																		
+YBR176W																																																																																																						
+YBR180W																																																																																																						
+YBR183W																																																																																																						
+YBR192W																																																																																																						
+YBR196C																																					0.40																																																																	
+YBR199W																																																																																																						
+YBR204C																																																																																																						
+YBR205W																																																																																																						
+YBR208C																																																																																																						
+YBR213W																																																																																																						
+YBR218C																																										0.00																																													0.00											0.00				
+YBR221C				1.00		1.00	1.00				1.00											1.00						1.00		1.00				1.00		1.00	1.00		0.00	1.00									1.00				0.00	1.00	1.00				1.00				1.00		1.00												1.00			1.00								1.00		1.00	1.00	0.00										
+YBR244W																																																																																																						
+YBR248C																																											1.00																																																											
+YBR249C		1.00																1.00		1.00																									1.00																1.00														1.00	1.00																				1.00						
+YBR252W																																																																																																						
+YBR256C																																																																																																						
+YBR263W									0.40																										0.40				0.00								0.40						0.40												0.40						0.40	0.40												0.40	0.40															0.40		
+YBR265W																																																																																																						
+YBR291C																																																																																																						
+YBR293W																																																																																																						
+YBR294W																																																																																																						
+YBR296C																																																																																																						
+YBR298C																																																																																																						
+YBR299W																																																																																																						
+YCL004W																																																																																																						
+YCL009C																																																																																							0.00											0.00				
+YCL018W																																																						1.00									1.00																								0.00											0.00				
+YCL025C																																																																																																						
+YCL030C																																											1.00																																																											
+YCL035C																																																																																																						
+YCL038C																																																																																																						
+YCL040W	0.00								0.00												0.00		0.00									0.00			0.00					0.00		0.00																		0.00												0.00											0.00							0.00												0.00
+YCL050C																								1.00													1.00																									1.00																									0.00											0.00				
+YCL052C																																																																																																						
+YCL064C																																																																																									0.00													
+YCL069W																																																																																																						
+YCR005C																																										0.00																																																												
+YCR010C																																																																																																						
+YCR012W																																																																																																						
+YCR024C																																																																																																						
+YCR024C-A																																																																																																						
+YCR028C																																																																																																						
+YCR034W																																																																																																						
+YCR036W																																																																																																						
+YCR037C																																																																																																						
+YCR048W																												0.40																									0.40																		0.40																			0.40	0.40											
+YCR053W	1.00				0.40				0.40										0.40						0.40		0.40												1.00	1.00																						1.00			1.00																						0.00							1.00				0.00				
+YCR075C																																																																																																						
+YCR083W																																																																																																						
+YCR098C																																																																																																						
+YCR105W																																																																	1.00																																					
+YDL004W																																														1.00																																																								
+YDL015C																																																																																																						
+YDL022W																																																																							0.40																															
+YDL042C																																																																																																						
+YDL045C																																																																																																						
+YDL052C			0.40																																		0.40		0.40								0.40																																											0.40										0.40		
+YDL055C																																																																																																						
+YDL066W	0.40		0.40		0.40				0.40	0.40		0.40	0.40		0.40	0.40			0.40		0.40	0.40	0.40		0.40	0.40	0.40	0.40	0.40			0.40	0.40			0.40	0.40		0.00	0.00	0.40	0.00		0.40		0.40				0.40	0.40		0.40			0.40	0.40	0.40	0.00	0.40				0.40	0.40	0.40	0.40	0.40	0.40		0.40			0.40			0.40	0.40	0.40	0.40	0.40	0.40		0.40	0.40	0.40	0.00			0.40			0.40					0.00	0.40	0.40	0.40	
+YDL067C																																																																																	1.00																					
+YDL078C																																																																																																						
+YDL080C																																																															1.00																																							
+YDL085W																																																																																																						
+YDL090C																																																																																																						
+YDL093W																																																																																																						
+YDL095W																																																																																																						
+YDL100C																																																																																																						
+YDL103C																																																																																																						
+YDL131W																																																											1.00																												0.00											0.00				
+YDL141W									0.40																						1.00						0.40					1.00						0.40				0.40																		1.00			1.00							0.40																						
+YDL142C																																																																																																						
+YDL168W																																					0.00																																																																	
+YDL171C																																							1.00																																	0.00																														
+YDL174C																																																																																																						
+YDL178W																																																																																																						
+YDL182W																																																																																																						
+YDL185W																																																																																																						
+YDL198C																																																																																																						
+YDL205C									0.40																																																																																													
+YDL210W																																																																																																						
+YDL215C																																			0.00																																																																			
+YDL238C																																																																																																						1.00
+YDL245C																																																																																																						
+YDL247W																																																																																																						
+YDR001C																																																																																																						
+YDR007W																																																																																																1.00						
+YDR017C																																																																																																						
+YDR019C																																							0.00															0.00					0.00				0.40																																							
+YDR023W																																																																																																						
+YDR035W																																																																																																						
+YDR037W																																																																																																						
+YDR044W									0.40																																																																																													
+YDR046C																																																																																																						
+YDR047W									0.40																																																																																													
+YDR050C																																																																																																						
+YDR058C																																																																																																						
+YDR062W																																																																																																						
+YDR072C																																																																																																						
+YDR074W																																																																																																						
+YDR098C																																																																																																						
+YDR127W																		1.00					1.00																						1.00																1.00														1.00	1.00								1.00												1.00						
+YDR135C																																																																																																						
+YDR147W																																																																																																						
+YDR148C	0.00											0.00									0.00											0.40							0.00	0.00														0.00			0.00		0.00	0.40			0.00					0.00	0.00			0.00		0.00																									0.00			
+YDR158W	1.00				0.40														0.40						0.40		0.40												1.00	1.00				1.00																		1.00			1.00																						0.00							1.00				0.00				
+YDR173C																																																																																																						
+YDR178W																																																																																																						
+YDR191W																																																																																																						
+YDR196C																																																																																																						
+YDR204W																																																																																																						
+YDR208W																																																																																																						
+YDR226W																																																																	0.40																						0.40				0.40							0.40				
+YDR232W									0.40																																																																																													
+YDR234W																																																																																							0.00											0.00				
+YDR236C																																																																																																						
+YDR256C																																																																																																						
+YDR261C																																																																																																						
+YDR268W																																																																																																						
+YDR272W																																																																																																						
+YDR284C																																																																																																						
+YDR287W																																																																																																						
+YDR294C																																																																																																						
+YDR297W																																																																																																						
+YDR298C																																														1.00																																																								
+YDR300C																																			0.00																1.00																																				0.00											0.00				
+YDR302W																																																																																																						
+YDR305C																																																																																																						
+YDR315C																																																																																																						
+YDR321W																																																																																																						
+YDR322C-A																																														1.00																																																								
+YDR341C																																																																																																						
+YDR342C																																																																																																						
+YDR343C																																																																																																						
+YDR345C																																																																																																						
+YDR353W																								1.00													1.00																									1.00																																								
+YDR354W																																																																																																1.00						
+YDR367W																																																																																																						
+YDR368W																																																																																																						
+YDR373W																																																																																																						
+YDR376W																																																																																																						
+YDR377W																																														1.00																																																								
+YDR380W																																																																	1.00											1.00																										
+YDR384C																																																																																																						
+YDR399W																																																																																																						
+YDR400W																																																																																																						
+YDR402C																																																																																																						
+YDR403W																																																																																																	0.00					
+YDR408C																																														1.00																																																								1.00
+YDR428C																																																																																																						
+YDR453C																																																																																																						
+YDR454C									0.40												0.40											0.40																												0.40																																										
+YDR481C																																																																																																						
+YDR483W																																																																																																						
+YDR487C																																																																																																						
+YDR497C																																																																																																						
+YDR502C																																																																																																						
+YDR503C		0.40	0.40	0.40		0.40	0.40	0.40	0.40		0.40							0.40		0.40	0.40	0.40		0.40				0.40		0.40	0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40	0.40			0.40	0.40	0.40	0.40	0.40	0.40	0.40				0.40	0.40	0.40				0.40	0.40	0.40	0.40	0.40		0.40					0.40	0.40	0.40	0.40		0.40	0.40	0.40			0.40								0.40	0.40	0.40	0.40			0.40		0.40	0.40			0.40		0.40
+YDR508C																																																																																																						
+YDR513W																																																																																																						
+YDR529C																																														1.00																																																								
+YDR530C																																																																																																						
+YDR531W																																																																																																						
+YDR536W																																																																																																						
+YEL006W																																																																																																						
+YEL017C-A																																																																																																						
+YEL021W									0.40																																																																																													
+YEL024W																																														1.00																																																								
+YEL027W																																																																																																						
+YEL029C																																																																																																						
+YEL038W																																																																																																						
+YEL039C																																															0.40																																																					0.40		
+YEL041W																																																																																																						
+YEL042W																																																																																																						
+YEL046C	1.00																																						1.00																																																															
+YEL047C																																																																																																						
+YEL051W																																																																																																						
+YEL058W																																																																																																						
+YEL063C																																																																																																						
+YEL069C																																																																																																						
+YEL071W																																																																																																						
+YER003C																																																																																																						
+YER005W																																																																																																						
+YER014W									0.40																																																																																													
+YER015W																																										0.00																																																												
+YER019W																																																																																																						
+YER023W																																																																													1.00																									
+YER024W																																																																																																						
+YER026C																																																																																																						
+YER037W																																																																																																						
+YER043C					0.40					0.40		0.40	0.40	0.40	0.40	0.40	1.00						0.40		0.40	0.40	0.40	1.00					0.40								0.40	0.40								0.40	0.40					0.40	0.40	0.40						0.40		0.40	0.40	0.40	0.40					0.40				0.40				0.40	0.40	0.40			0.40						0.40					0.40	0.40		0.40	
+YER052C	1.00				0.40														0.40						0.40		0.40												1.00	1.00				1.00																		1.00			1.00																						0.00							1.00				0.00				
+YER053C																																																																																																						
+YER055C																																											1.00																																																											
+YER056C																																																																																																						
+YER060W																																																																																																						
+YER060W-A																																																																																																						
+YER061C																																																																																																						
+YER062C																																						1.00																																																																
+YER065C																																							1.00																																																															
+YER069W	0.40		0.40		0.40	1.00	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40		0.40		0.40	1.00	0.40	0.40	0.40	0.40	0.40	0.40	0.40		0.40	0.40	0.40		0.40	0.40	0.40	0.40			0.40	0.40	0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40	0.40				0.40	0.40	0.40		0.40		0.40		0.40		0.40	0.40	0.40	0.40	0.40		0.40	0.40	0.40			1.00	0.40	0.40	1.00		0.40	0.40	0.40	0.40	0.40	0.00		0.40	1.00		0.40	0.40	0.40				0.00	0.40	0.40	0.40	0.40
+YER070W					0.00					0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00				0.00		0.00	0.00	0.00		0.00				0.00								0.00	0.00								0.00						0.00	0.00	0.00						0.00		0.00	0.00	0.00	0.00					0.00				0.00	0.00			0.00	0.00	0.00		0.00	0.00						0.00					0.00	0.00		0.00	
+YER073W																																																																																																						
+YER081W																							0.00																	0.00		0.00																																									0.00	0.00			0.00											0.00				
+YER086W																																																														1.00			1.00																																					
+YER090W																																																																																																1.00						
+YER091C					0.40					0.40		0.40	0.40	0.40	0.40	0.40	1.00						0.40		0.40	0.40	0.40	1.00					0.40								0.40	0.40								0.40	0.40					0.40	0.40	0.40				1.00		0.40		0.40	0.40	0.40	0.40					0.40				0.40				0.40	0.40	0.40			0.00						0.40					0.00	0.40		0.40	
+YER099C																																											1.00			1.00																																																		1.00						
+YER119C																																																																																																						
+YER152C																																																																																							0.00											0.00				
+YER170W																																																																																																						
+YER174C																																																																																																						
+YER175C																																																																																																						
+YER178W				1.00		1.00	1.00				1.00											1.00						1.00		1.00				1.00		1.00	1.00		0.00	1.00									1.00				0.00	1.00	1.00				1.00				1.00		1.00												1.00			1.00								1.00		1.00	1.00	0.00										
+YER183C																																																																																																						
+YFL001W																																																																																																						
+YFL011W																																																																																																						
+YFL017C																																																																																																						
+YFL018C			0.40		0.40					0.40		0.40	0.40	0.40	0.40	0.40			0.40				0.40		0.40	0.40	0.40		0.40				0.40						0.00		0.40	0.40					0.40			0.40		0.40					0.40	0.40						0.40		0.40	0.40		0.40					0.40				0.40	0.40		0.40	0.40	0.40			0.40			0.40				0.40							0.40	0.40	
+YFL022C																																																																																																						
+YFL030W			0.00																																				1.00																																																															
+YFL045C																																																																																																						
+YFL053W																																																																																																						
+YFL055W																																																																																																						
+YFR015C																																																																																																						
+YFR019W																																																																																																						
+YFR025C									0.40																																		1.00																																																											
+YFR030W																								1.00													1.00																									1.00																																								
+YFR033C																																														1.00																																																								
+YFR047C																																																																																																						
+YFR053C									0.00												0.00											0.00			0.00					0.00		0.00				0.00			0.00											0.00												0.00											0.00							0.00		0.00										0.00
+YGL001C									0.40																																																																																													
+YGL008C																																																																																																						
+YGL009C																																																																																							0.00											0.00				
+YGL012W																												1.00																																																																										
+YGL026C									0.40																																																																																							1.00						
+YGL037C																																																																																																						
+YGL040C									0.40																																																																																													
+YGL055W																															1.00																																																																							
+YGL062W																																1.00				1.00	1.00		1.00			0.00		1.00					1.00					1.00						1.00		1.00	1.00		1.00															1.00							0.00							1.00				0.00				
+YGL063W																																																																																																						
+YGL067W																																																																																																						
+YGL077C																																																																																																						
+YGL080W																																																																																																						
+YGL084C																																																																																																						
+YGL119W																																																																																																						
+YGL125W																	1.00																																													1.00																									0.00											0.00				
+YGL142C																																																																																																						
+YGL148W																		1.00					1.00																						1.00																1.00														1.00	1.00								1.00												1.00						
+YGL154C																																																											1.00																												0.00											0.00				
+YGL184C																																																																																							0.00											0.00				
+YGL186C																																																																																																						
+YGL187C																																																																																																						
+YGL191W																																																																																																						1.00
+YGL202W																																																																																																						
+YGL205W																																																																																																						
+YGL224C																																																																																																						
+YGL225W																																																																																																						
+YGL234W																																														1.00																																																								1.00
+YGL245W																																																																																																						
+YGL248W																																																																																																						
+YGL253W	0.00								0.00												0.00											0.00			0.00					0.00		0.00																		0.00												0.00											0.00							0.00		0.00										0.00
+YGL256W																																																																																																						
+YGR007W																																																																																																						
+YGR010W																																																																																																						
+YGR019W																																																																								0.00																														
+YGR020C																																																																																																						
+YGR032W																																																																																																						
+YGR055W																																																																																																						
+YGR060W									0.40																			1.00																																																																										
+YGR061C																																														1.00																																																								1.00
+YGR065C																																																																																																						
+YGR087C																																							0.00																																																															
+YGR088W																																																																																																						
+YGR094W																																																																																																						
+YGR096W																																																																																																						
+YGR110W																																																																																																						
+YGR121C																																																																																																						
+YGR124W																																																																																																						
+YGR138C																																																																																																						
+YGR143W																																																																																																						
+YGR155W																								1.00																																																																														
+YGR157W																																																																																																						
+YGR170W																																																																																																						
+YGR171C																																																																																																						
+YGR175C											1.00																	1.00																																																																										
+YGR177C																																															0.00																																																							
+YGR180C					0.00					0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00				0.00		0.00	0.00	0.00		0.00				0.00								0.00	0.00								0.00						0.00	0.00	0.00						0.00		0.00	0.00	0.00	0.00					0.00				0.00	0.00			0.00	0.00	0.00		0.00	0.00						0.00					0.00	0.00		0.00	
+YGR183C																																														1.00																																																								
+YGR185C																																																																																																						
+YGR191W																																																																																																						
+YGR192C																																																																																																						
+YGR193C				1.00		1.00	1.00				1.00											1.00						1.00		1.00				1.00		1.00	1.00		0.00	1.00									1.00				0.00	1.00	1.00				1.00				1.00		1.00												1.00			1.00								1.00		1.00	1.00	0.00										
+YGR194C																																																																																																						
+YGR202C																																																																		0.00					0.00																0.00												0.00			
+YGR204W									0.40																												0.40										0.40																																																							
+YGR208W	0.00								0.40												0.40		0.00	1.00															1.00	0.00		0.00				1.00	0.40				0.00	0.40	0.40												0.40						0.40						0.40			0.40			0.00	0.00	0.40		0.00											0.00		0.40		
+YGR209C																																																																																																						
+YGR240C																																																																																																						
+YGR243W																																																																																																						
+YGR244C																																																																																																						
+YGR247W																																																																																																						
+YGR248W																																						0.00		0.00																																0.00																				0.00										
+YGR254W																																																																																																						
+YGR255C																																																																																																						
+YGR256W																																						0.00		0.00																																0.00																														
+YGR260W																																																																																																						
+YGR264C																																																																																																						
+YGR267C																																																																																																						
+YGR277C																																																																																																						
+YGR282C																																																																																																						
+YGR286C																																																																																																						
+YGR287C																																																																																																						
+YGR289C																																																																																																						
+YGR292W																																																																																																						
+YHL003C																																																																																																						
+YHL011C																																																																																																						
+YHL016C																																																																																																						
+YHL032C																																						0.00																																																																
+YHL036W																																																																																																						
+YHR001W-A																																														1.00																																																								
+YHR002W																																																																																																						
+YHR007C																												1.00																																																																										
+YHR011W																																																																																									0.00													
+YHR018C									0.40																																																																																													
+YHR019C																																																																																																						
+YHR020W																																																																																																						
+YHR025W	1.00				0.40														0.40						0.40		0.40												1.00	1.00																						1.00			1.00																						0.00							1.00				0.00				
+YHR026W																																																																																																						
+YHR037W																																																																																																						
+YHR039C-A																																																																																																						
+YHR042W																												1.00																																																																										
+YHR046C																																																																																																						
+YHR051W																																																																																																						
+YHR063C																																																																																																						
+YHR067W																																																																																																						
+YHR068W																																																																																																						
+YHR072W																												1.00																																																																										
+YHR074W																																																																																																						
+YHR091C																																																																																																						
+YHR092C																																																																																																						
+YHR094C																																																																																																						
+YHR096C																																																																																																						
+YHR100C																																																																																																						
+YHR104W																																																																																																						
+YHR106W																																																																																																						
+YHR123W																																																																		0.00					0.00							0.00									0.00												0.00			
+YHR128W																																																																																																						
+YHR137W																																																																																																						
+YHR144C			0.40																																		0.40	0.40																																					0.40														0.40								0.40			0.40		
+YHR162W																																																																																																						
+YHR163W	0.00					1.00	1.00	1.00									1.00	1.00				1.00		1.00							1.00						1.00	0.00	0.00	0.00			1.00	1.00									1.00						1.00		1.00	1.00			1.00					1.00		0.00	1.00		1.00	1.00	1.00			1.00												0.00		1.00		1.00						
+YHR174W																																																																																																						
+YHR183W	0.00					1.00	1.00	1.00									1.00	1.00				1.00		1.00							1.00						1.00	0.00	0.00	0.00			1.00	1.00															1.00		1.00	1.00			1.00					1.00		0.00	1.00		1.00	1.00	1.00			1.00									1.00			0.00		1.00		1.00						
+YHR190W											1.00																	1.00																																																															1.00											
+YHR208W																																																																																																						
+YHR216W																																																																																																						
+YIL002C																																																																																																						
+YIL006W																																																																																																						
+YIL009W																																																																																																						
+YIL010W																																																																																																						
+YIL013C																																																																																																						
+YIL020C																																											1.00																																																											
+YIL053W																																																																																																						
+YIL066C					0.00					0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00				0.00		0.00	0.00	0.00		0.00				0.00								0.00	0.00								0.00						0.00	0.00	0.00						0.00		0.00	0.00	0.00	0.00					0.00				0.00	0.00			0.00	0.00	0.00		0.00	0.00						0.00					0.00	0.00		0.00	
+YIL074C	0.00																						0.00																1.00	0.00		0.00																																									0.00	0.00			0.00											0.00				
+YIL078W																																																																																																						
+YIL083C																																																																																																						
+YIL094C																																																											1.00																												0.00											0.00				
+YIL099W																																																																																																						
+YIL107C																																																																																																						
+YIL111W																																																																																																						
+YIL116W									0.40																																		1.00																																																											
+YIL124W																																																																																																						
+YIL125W												0.00									0.00											0.40							0.00	0.00														0.00			0.00		0.00	0.40			0.00					0.00	0.00			0.00		0.00																									0.00			
+YIL134W																																																																																																						
+YIL145C																																																																																																						
+YIL155C																																																																																																						
+YIL160C																																																																																																						
+YIL162W																																																																																																						
+YIL172C																																																																																																						
+YIR027C																																																																																																						
+YIR028W																																																																																																						
+YIR029W																																																																																																						
+YIR031C																																																																																																						
+YIR032C																																																																																																						
+YIR034C																																																											1.00																												0.00											0.00				
+YIR037W																																																																																																						
+YJL005W																																																																																																						
+YJL026W																																																																																																						
+YJL045W																																																																																																						
+YJL052W																																																																																																						
+YJL060W																																																																																																						
+YJL068C																																																																																																						
+YJL071W																																																																																																						
+YJL088W						1.00																1.00																																																																	0.00											0.00				
+YJL091C																																																																																																						
+YJL097W																																																																																																						
+YJL100W																																																																																																						
+YJL101C																																			0.00		1.00																																																																	
+YJL121C																																																																																																						
+YJL129C																																																																																																						
+YJL130C																																																																																							0.40											0.40				
+YJL134W																																																																																																						
+YJL137C																																																																																																						
+YJL139C																																																																																																						
+YJL153C																																																																																																						
+YJL155C																																																																																																						
+YJL166W																																														1.00																																																								
+YJL167W				1.00			1.00				1.00																	1.00		1.00																																						1.00																				1.00			1.00								1.00			
+YJL196C																																																																																																						
+YJL198W																																																																																																						
+YJL212C																																																																																																						
+YJL214W																																																																																																						
+YJL216C																																																																																																						
+YJL219W																																																																																																						
+YJL221C																																																																																																						
+YJR001W																																																																																																						
+YJR009C																																																																																																						
+YJR010W																																																																																																						
+YJR013W																																																																																																						
+YJR016C																																																																																																						
+YJR019C																																																																																																						
+YJR025C																																																																																																						
+YJR048W																																															0.40																																																					0.40		
+YJR049C																																																																																																						
+YJR057W																																																																																																						
+YJR073C																																																																																																						
+YJR077C																																																																																																						
+YJR078W																																																																																																						
+YJR095W																																																																																																						
+YJR103W																																																																																																						
+YJR105W					0.40					0.40		0.40	0.40	0.40	0.40	0.40									0.40	0.40	0.40	1.00					0.40								0.40	0.40								0.40	0.40					0.40	0.40	0.40						0.40		0.40	0.40	0.40	0.40					0.40				0.40				0.40	0.40	0.40			0.40						0.40					0.40	0.40		0.40	
+YJR109C						1.00																1.00																																																																																
+YJR110W																																																																																																						
+YJR121W																																																																																																						
+YJR130C																																																																																							0.00											0.00				
+YJR133W																																																																																																						0.00
+YJR137C																								1.00													1.00																									1.00																																								
+YJR139C	1.00				0.40														0.40						0.40		0.40												1.00	1.00				1.00																		1.00			1.00																						0.00							1.00				0.00				
+YJR143C																																																																																																						
+YJR148W														0.40																																																																																								
+YJR152W																																																																																																						
+YJR153W																																																																																																						
+YJR158W																																																																																																						
+YJR159W																																																																																																						
+YJR160C																																																																																																						
+YKL001C																								1.00													1.00																									1.00																									0.00											0.00				
+YKL004W																																																																																																						
+YKL008C																																																																																																						
+YKL016C																																														1.00																																																								
+YKL019W																																																																																																						
+YKL024C									0.40																																																																																													
+YKL026C																																																																																																						
+YKL029C		0.00			0.40	1.00		0.40	0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40	0.00	0.40	0.00		1.00		0.40	0.40	0.40	0.40		0.40		0.40		0.40								0.40		0.40		0.00			0.40		0.40				1.00			0.40	0.40			0.00	0.40	1.00	0.40		0.40	0.40	0.40	0.40	0.40			0.40	0.40	0.00	0.00	1.00	0.40	0.40	1.00		0.40	0.40	0.00		0.40				1.00			0.40	0.40		0.00	0.00		0.40		0.40	
+YKL035W																																																																																																						
+YKL055C																																																																																																						
+YKL060C																																																																																																						
+YKL067W																																															0.40	0.40					0.40																		0.40										0.40										0.40											
+YKL080W																																																																																																						
+YKL085W					0.40					0.40		0.40	0.40	0.40	0.40				0.40						0.40	0.40	0.40		0.40				0.40								0.40															0.40	0.40	0.40						0.40		0.40	0.40	0.40	0.40					0.40				0.40	0.40							0.40							0.40						0.40		0.40	
+YKL088W																																																																																																						
+YKL094W																																																																																																						
+YKL104C																																																																																																						
+YKL106W																																																																																																						
+YKL120W																																																																																																						
+YKL127W																																																																																																						
+YKL132C																																																																																																						
+YKL140W																																																																																																						
+YKL141W																																																																																																						
+YKL146W																																																																																																						
+YKL148C																																																																																																						
+YKL152C																																																																																																						
+YKL165C																																																																																																						
+YKL181W																																											1.00			1.00																																																		1.00						
+YKL182W																																																																																																						
+YKL184W																																																																							0.00									1.00																						
+YKL188C																																																																																																						
+YKL192C																																																																																																						
+YKL194C																																																																																																						
+YKL211C																																																																																																1.00						
+YKL212W																																																																																																						
+YKL216W																																																																																																						
+YKL217W																																																																																																						
+YKR009C																																																																																																						
+YKR031C																																																																																																						
+YKR039W																																																																																																						
+YKR043C																																																																																																						
+YKR053C																																																																																																						
+YKR058W																																																																																																						
+YKR061W																																																																																																						
+YKR066C																																																																																																						
+YKR067W																																																																																																						
+YKR069W																																																																																																						
+YKR072C																																																																																																						
+YKR080W																																																																																																						
+YKR089C																																																																																																						
+YKR097W																																																																																																						
+YLL012W																																																																																																						
+YLL015W																																																																																																						
+YLL018C																																																																																																						
+YLL028W																																																																																																						
+YLL031C																																																																																																						
+YLL041C																																																																																																						
+YLL043W																																																																																																						
+YLL048C																																																																																																						
+YLL052C																																																																																																						
+YLL057C																																																																								0.00																														
+YLL061W																																																																																																						
+YLL062C																																																																																																						
+YLR011W																																																																																																						
+YLR017W																																																																																																						
+YLR020C																																																																																																						
+YLR027C																																																																																																						
+YLR028C																																																																																																						
+YLR038C																																																																																																						
+YLR043C																																																																																							0.00											0.00				
+YLR044C																	1.00														1.00								0.00														1.00																	1.00			1.00											1.00	1.00																	
+YLR056W																																																																																																						
+YLR058C									0.40																												0.40										0.40						0.40												0.40						0.40																													0.40		
+YLR060W																																																																																																						
+YLR070C																																																																																																						
+YLR081W																																																																																																						
+YLR089C																																																																																																						
+YLR092W																																																																																																						
+YLR100W																																																																																																						
+YLR109W																																																																																																						
+YLR133W																	0.00																																																	0.00					0.00																0.00												0.00			
+YLR134W																																							0.00																																																															
+YLR138W																																																																																																						
+YLR142W																																																																																																						
+YLR146C																																																																																																						
+YLR153C																															1.00								1.00			1.00											1.00												0.40					1.00			1.00																		0.40											
+YLR155C																																																																																							0.00											0.00				
+YLR157C																																																																																							0.00											0.00				
+YLR158C																																																																																							0.00											0.00				
+YLR160C																																																																																							0.00											0.00				
+YLR172C																																																																																																						
+YLR174W														0.40																																																																					0.40																			0.40
+YLR180W																												1.00																																																																										
+YLR189C																												0.00																																																																										
+YLR201C																																																																																																						
+YLR209C																																																																																																						
+YLR231C																																																																																																						
+YLR237W																																																																																																						
+YLR240W																																																																																																						
+YLR245C																																																																																																						
+YLR258W																																																																																																						
+YLR260W																																																																																																						
+YLR284C																																																																																																						
+YLR285W																																																																																																						
+YLR295C																																														1.00																																																								
+YLR299W			0.00																																		0.00																																																																	
+YLR300W																																																																																																						
+YLR303W																																																																																																						
+YLR304C																																																																																																						
+YLR305C																																																																																																						
+YLR307W																																																																																																						
+YLR308W																																																																																																						
+YLR328W																																																																																																						
+YLR342W																																																																																																						
+YLR348C																																																																																																						
+YLR354C																																																																																																						
+YLR355C																																																																																																						
+YLR359W																																																																																																						
+YLR372W																																																																																																						
+YLR377C																																																																																																						
+YLR382C																																																																																																						
+YLR386W																																																																																																						
+YLR395C																																																																																																						
+YLR410W																																																																																																						
+YLR420W																																																																																																						
+YLR432W																																																																																																						
+YLR438W	0.40		0.40		0.00	0.40	0.40	0.40	0.40	0.00	0.40	0.00	0.00	0.00	0.00	0.00	0.00		0.00		0.40	0.40	0.00	0.40	0.00	0.00	0.00	0.40	0.00		0.40		0.00		0.40	0.40	0.40	0.00			0.00	0.00	0.40	0.40		0.40	0.40	0.40	0.40	0.00	0.00	0.40				0.00	0.00	0.00				0.40		0.00		0.00	0.00	0.00	0.00	0.40	0.40	0.00	0.40	0.00			1.00	0.00	0.00	0.40		0.00	0.00	0.00	0.40	0.00			0.40	0.40		0.00	0.00	0.40					0.00	0.40	0.00	0.40
+YLR447C																																																																																																						
+YLR450W																																																																																																						
+YML004C																																																																																																						
+YML008C																																																																																																						
+YML022W																																																																			0.00																																			
+YML035C																																																																																																						
+YML042W																																							1.00																																																															
+YML054C																																																																																																						
+YML056C																																																																																																						
+YML059C																																																																		0.00					0.00																0.00												0.00			
+YML070W																																																																																																						
+YML075C				1.00			1.00				1.00																			1.00				1.00																					1.00																																	1.00			1.00											
+YML081C-A																																														1.00																																																								
+YML086C																																																																																																						
+YML100W																																																																																																						
+YML106W																																																																																																						
+YML110C																																																																																																						
+YML120C																																																																																																						
+YML123C																																																																																																						
+YML126C							1.00				1.00																																													1.00																																														
+YMR006C																																																																																																						
+YMR008C																																																																																																						
+YMR009W																																																																																																						
+YMR011W																																																																																																						
+YMR013C																																																																																																						
+YMR015C																																																																																																						
+YMR020W																																																																																										0.00												
+YMR041C																																																																																																						
+YMR054W																																																																																																						
+YMR056C																																																																																																						
+YMR062C			0.40		0.40				0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40		0.40		0.40				0.40	0.40	0.40	0.40	0.40			0.40	0.40		0.40		0.40	0.40			0.40	0.40					0.40	0.40		0.40						0.40	0.40	0.40		0.40				0.40		0.40	0.40	0.40	0.40			0.40		0.40				0.40	0.40			0.40	0.40	0.40		0.40	0.00		0.40			0.40	0.40					0.00	0.40	0.40	0.40	0.40
+YMR083W																																																																																																						
+YMR088C																																																																																																						
+YMR101C																																																																																																						
+YMR105C																																																																																																						
+YMR108W																																																																																																						
+YMR113W																																																																																																						
+YMR120C																																																																																																						
+YMR145C																																																																																																						
+YMR165C																																																																																																						
+YMR169C																																																																																																						
+YMR170C																																																																																																						
+YMR189W																																							0.00															0.00					0.00				0.40																																							
+YMR202W																																																																																																						
+YMR205C						1.00		1.00																							1.00					1.00			1.00			1.00										1.00											1.00									1.00	1.00				1.00			1.00	1.00			1.00																		
+YMR207C																																																																																																						
+YMR208W				1.00			1.00				1.00																	1.00		1.00				1.00																					1.00	1.00												1.00																				1.00			1.00								1.00			
+YMR217W																																																																																																						1.00
+YMR220W				1.00			1.00				1.00																	1.00		1.00				1.00																					1.00	1.00												1.00																				1.00			1.00								1.00			
+YMR226C																																																																																																						
+YMR241W																																																																																																						
+YMR246W					0.00					0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00				0.00		0.00	0.00	0.00		0.00				0.00								0.00	0.00								0.00						0.00	0.00	0.00						0.00		0.00	0.00	0.00	0.00					0.00				0.00	0.00			0.00	0.00	0.00		0.00	0.00						0.00					0.00	0.00		0.00	0.40
+YMR250W																																			0.00																																																																			
+YMR256C																																																																																																						
+YMR261C																																																																																																						
+YMR267W	0.40				0.40			1.00	0.40	0.40		0.40	0.40	0.40	0.40	0.40	1.00		0.40	0.40	0.00	0.40	0.40		0.40	0.40	0.40		0.40		1.00	0.00	0.40								0.40		1.00	0.40						0.40	0.40		1.00			0.40	0.40	0.40		0.00	0.40			0.40	0.40	0.40	0.40	0.40	0.40	1.00		0.00	1.00	0.40				0.40	0.40			0.40				0.40	0.40			0.40		0.00						0.40	0.40		0.40	
+YMR271C																																																																																																						
+YMR272C																																																																																																						
+YMR278W																																																																																																						
+YMR281W																																																																																																						
+YMR289W																																																																																																						
+YMR293C																																																																																																						
+YMR296C																																																																																																						
+YMR298W																																																																																																						
+YMR300C																																														1.00																																																								1.00
+YMR303C																																																																																	0.40																					
+YMR313C																																																																																																						
+YMR318C																																																																																																						
+YMR319C									0.40																																																																																													
+YNL003C																																																																																																						
+YNL009W																																																																																																						
+YNL029C																																																																																																						
+YNL037C																																						1.00																																																	0.00					1.00						0.00				
+YNL045W																																																																																																						
+YNL052W																																																																																																						
+YNL071W				1.00		1.00	1.00				1.00											1.00						1.00		1.00				1.00		1.00	1.00		0.00	1.00									1.00				0.00	1.00	1.00				1.00				1.00		1.00												1.00			1.00								1.00		1.00	1.00	0.00										
+YNL073W																																																																																																						
+YNL101W																																																																																																						
+YNL104C																					0.00																		0.00	0.00																																															0.00											0.00				
+YNL106C																																																																																																						
+YNL117W																																																																																																						
+YNL129W																																																																																																						
+YNL130C																																																																		0.00					0.00																0.00												0.00			
+YNL141W																																																																																																						
+YNL142W																																																																																																						
+YNL169C																																																																																																						
+YNL192W																																																																																																						
+YNL202W																																																																																																						
+YNL220W																																											1.00																																																											
+YNL241C	0.00					1.00	1.00	1.00									1.00	1.00		0.40		1.00		1.00				1.00			1.00						1.00	0.00	0.00	0.00			1.00	1.00	0.40								1.00						1.00		1.00	1.00			1.00					1.00		0.00	1.00		1.00	1.00	1.00			1.00										1.00		0.00		1.00		1.00						
+YNL247W																																																																																																						
+YNL256W																																																																																																						
+YNL267W																																																																																																						
+YNL268W																																																																																																						
+YNL270C																																																																																																						
+YNL277W																																																																																																						
+YNL280C																												1.00																																																																										
+YNL292W																																																																																																						
+YNL316C									0.40									1.00																																											1.00														1.00	1.00																										
+YNL318C																																																																																																						
+YNL325C																																																																																																						
+YNR001C						1.00																1.00														1.00	1.00		1.00			1.00							1.00				0.00						1.00																		1.00			1.00																						
+YNR008W																																																																		0.00					0.00																0.00												0.00			
+YNR012W																																																																																																						
+YNR013C																																																																																																						
+YNR016C																															1.00											1.00											1.00																	1.00			1.00																													
+YNR019W																												0.40																									0.40												0.40						0.40																			0.40	0.40				0.00							
+YNR033W																																																																																																						
+YNR041C																																																																																																						
+YNR043W				1.00			1.00				1.00																	1.00		1.00				1.00																					1.00	1.00												1.00																				1.00			1.00								1.00			
+YNR050C																																																											1.00																												0.00											0.00				
+YNR056C																																																																																																						
+YNR057C																																																																																																						
+YNR058W																																																																																																						
+YNR067C																																																																																																						
+YNR072W																																																																																																						
+YOL011W																																																																																																						
+YOL020W																																																																																																						
+YOL033W																																																																																																						
+YOL049W																																							0.00																																																															
+YOL052C																																																																																																						
+YOL055C																																																																																																						
+YOL058W																																																																																																						
+YOL059W																																																																																																						
+YOL061W																																																																																																						
+YOL064C																								1.00													1.00																									1.00																									0.00											0.00				
+YOL065C																																																																																																						
+YOL066C																																																																																																						
+YOL068C																																																																																																						
+YOL086C																																																																																																						
+YOL096C																																																																																																						
+YOL097C																																																																																																						
+YOL103W																																																																																																						
+YOL126C					0.40				0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40		0.40						0.40	0.40	0.40		0.40				0.40					0.40			0.40	0.00						0.40		0.40			0.00			0.40	0.40	0.40						0.40		0.40	0.40	0.40	0.40					0.40	0.40			0.40	0.40			0.40	0.40	0.40		0.40	0.40						0.40				0.40	0.40	0.40		0.40	0.00
+YOL136C																																																																																																						
+YOL140W	0.40		0.40		0.40	1.00	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40	0.40		0.40		0.40	1.00	0.40	0.40	0.40	0.40	0.40	0.40	0.40		0.40	0.40	0.40		0.40	0.40	0.40	0.40			0.40	0.40	0.40	0.40		0.40	0.40	0.40	0.40	0.40	0.40	0.40				0.40	0.40	0.40		0.40		0.40		0.40		0.40	0.40	0.40	0.40	0.40		0.40	0.40	0.40			1.00	0.40	0.40	1.00		0.40	0.40	0.40	0.40	0.40	0.00		0.40	1.00		0.40	0.40	0.40				0.00	0.40	0.40	0.40	0.40
+YOL143C									0.40																																																																																													
+YOL151W																																																																																																						
+YOL156W																																																																																																						
+YOR011W																																																																																																						
+YOR025W																																																																																																						
+YOR040W																																																																																																						
+YOR054C																																																																																																						
+YOR065W																																														1.00																																																								
+YOR071C																																																																																																						
+YOR074C									0.40																																																																																													
+YOR081C																																																																																																						
+YOR095C																																						0.40	0.40	0.40																																0.40																				0.40										
+YOR099W																																																																																																						
+YOR100C																																																																																																						
+YOR108W																																							1.00																																																															
+YOR109W																																																																																																						
+YOR120W																																																																																																						
+YOR125C																																																																																																						
+YOR126C																																																																																																						
+YOR128C																																														1.00																																																								1.00
+YOR130C																																																																																																						
+YOR136W																																						1.00																																																	0.00					1.00						0.00				
+YOR142W																																																																																																						
+YOR143C																																																																																																						
+YOR155C																																														1.00																																																								
+YOR163W																																																																																																						
+YOR168W																																																																																																						
+YOR171C																																																																																																						
+YOR175C		0.40	0.40	0.40														0.40		0.40		0.40		0.40						0.40				0.40			0.40		0.40								0.40							0.40	0.40						0.40									0.40						0.40				0.40					0.40			0.40		0.40		0.40		0.40						0.40		
+YOR176W									0.40																																																																																													
+YOR180C																																																																																																						
+YOR184W	0.00								0.40												0.40		0.00	1.00															1.00	0.00		0.00				1.00	0.40				0.00	0.40	0.40												0.40						0.40						0.40			0.40			0.00	0.00	0.40		0.00		1.00									0.00		0.40		
+YOR190W																																																																																																						
+YOR192C																																																																																																						
+YOR202W									0.40																																		1.00																																																											
+YOR209C																																																																																																						
+YOR221C																																																																																																						
+YOR222W																																																																																																						
+YOR236W									0.40																																																																																													
+YOR241W																																																																																																						
+YOR245C			0.40																									0.40							0.40		0.40	0.40	0.40								0.40	0.40					0.40												0.40						0.40				0.40														0.40	0.40	0.40				0.00		0.40			0.40		
+YOR270C																																																																																																						
+YOR273C																																																																																																						
+YOR278W																																																																																																						
+YOR303W						1.00																1.00																																																																																
+YOR311C																																																																																																						
+YOR317W					0.00					0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00				0.00		0.00	0.00	0.00		0.00				0.00								0.00	0.00								0.00						0.00	0.00	0.00						0.00		0.00	0.00	0.00	0.00					0.00				0.00	0.00			0.00	0.00	0.00		0.00	0.00						0.00					0.00	0.00		0.00	0.40
+YOR321W																																																																																																						
+YOR323C																																																			1.00																																				0.00					1.00						0.00				
+YOR332W																																																																																																						
+YOR335C																																																																																																						
+YOR347C																																																																																																						
+YOR348C																																																																																																						
+YOR360C																																																																																																						
+YOR374W																																																																																																						
+YOR375C																																								0.40																																															0.00											0.00				
+YOR377W																																															0.00																																																							
+YOR388C	0.00				0.00				0.40	0.00		0.00	0.00	0.00	0.00	0.00	0.00		0.00						0.00	0.00	0.00		0.00				0.00				0.40			0.00	0.00						0.40			0.00	0.00	0.40	0.40			0.00	0.00	0.00	0.00					0.00	0.40	0.00	0.00	0.00	0.00		0.40	0.00		0.00			0.40	0.00	0.00	0.40		0.00				0.00	0.00						0.00					0.00	0.00	0.40	0.00	
+YPL015C																																																																																																						
+YPL023C																																																																																							0.00											0.00				
+YPL028W									0.40																																																																																													
+YPL036W																																																																																																						
+YPL040C																																																																																																						
+YPL053C																																																																																																						
+YPL057C																																																																																																						
+YPL059W																																																																																																						
+YPL061W	1.00								0.40								1.00			0.40		0.40									1.00	0.00							1.00	1.00				0.40		0.40							1.00							0.00					0.40					1.00		0.00	1.00														0.40			0.40	0.40	0.00						0.40				0.40
+YPL069C																																																																																																						
+YPL078C																																														1.00																																																								
+YPL087W																																																																																																						
+YPL091W																																																																																																						
+YPL092W																																																																																																						
+YPL097W																																																																																																						
+YPL104W																																																																																																						
+YPL110C																																																																		0.00					0.00																0.00												0.00			
+YPL111W																																																																																																						
+YPL117C									0.40																																																																																													
+YPL134C																																																																																																						
+YPL147W																																																																																																						
+YPL148C																																																																																																						
+YPL160W																																																																																																						
+YPL172C									0.40																																																																																													
+YPL188W																																																																																																						
+YPL189W																																																																																																						
+YPL206C																																																																																																						
+YPL212C																																																																																																						
+YPL214C																																																																																																						
+YPL231W																																																																																																						
+YPL234C																																																																																																						
+YPL244C																																																																																																						
+YPL252C																																																																																																						
+YPL258C																																																																																																						
+YPL262W																																																																																																						
+YPL265W																																																																																																						
+YPL268W																																																																																																						
+YPL271W																																														1.00																																																								
+YPL273W																																																																																																						
+YPL274W																																																																																																						
+YPR001W																																																					0.00																																																	
+YPR002W																																																																																																						
+YPR006C																																																																																																						
+YPR020W																																														1.00																																																								1.00
+YPR021C																																																																																																						
+YPR026W																																																																																																						
+YPR033C																																																																																																						
+YPR035W						1.00		1.00														1.00														1.00			1.00				1.00			1.00																																																		1.00						1.00
+YPR036W																																																																																																						
+YPR047W																																																																																																						
+YPR060C																		1.00																											1.00																1.00														1.00	1.00							1.00																			
+YPR062W																																																																																																						
+YPR069C																																																																																										1.00												
+YPR074C																																																																																																						
+YPR081C																																																																																																						
+YPR113W																																																																																																						
+YPR121W																																																																																																						
+YPR128C																																																																																																						
+YPR138C																																																																																																						
+YPR140W																																																																							0.00																															
+YPR145W								1.00																																																																																														
+YPR156C																																																																																																						
+YPR159W																																																																																																						
+YPR160W																																																																																																						
+YPR167C																								1.00													1.00																									1.00																									0.00											0.00				
+YPR183W																																																																																																						
+YPR184W																																																																																																						
+YPR191W																																														1.00																																																								
+YPR192W																																																																																																						
+YHR215W																																																																																																						
+YMR058W																																																																																																						
+YDR538W																																																																																																						
+YDR539W																																																																																																						
+YJR024C																																																																																																						
+YPR118W																																																																																																						
+YAR069W-A																																																																																																						
+YHR214W-F																																																																																																						
+YDL040C																																																																																									0.00													
+YGR147C																																																																																																						
+YHR013C																																																																																									0.00													
+YFL058W																																																																																																						
+YDR071C																																																																																										0.00												
+YFR055W																																																																																							0.00											0.00				
+YDL166C																																																																	0.40																										0.40											
+YDR020C																																																																																																						
+YCL005W-A																																																																																																						
+YJL180C																																																																																																						
+YLR393W																																																																																																						
+YNL315C																																																																																																						
+YOL077W-A			0.40		0.40					0.40		0.40	0.40	0.40	0.40	0.40			0.40				0.40		0.40	0.40	0.40		0.40				0.40								0.40					1.00	0.40			0.40	0.40						0.40	0.40						0.40		0.40	0.40	0.40	0.40					0.40				0.40	0.40		0.40	0.40	0.40			0.40	0.40						0.40					0.40	0.40		0.40	
+YJR069C																																																																																																						
+YLL058W																																																																																																						
+YML082W																																																																																							0.40											0.40				
+YLR345W																																																																																																						
+YLR446W									0.00												0.00		0.00									0.00			0.00					0.00		0.00																		0.00												0.00											0.00							0.00		0.00										0.00
+YMR084W																																																																																																						
+YMR110C																																																																																																						
+YNL229C																																																																																																						
+YNR027W																																																																																																						
+YOL092W																																																																																																						
+YMR323W																																																																																																						
+YOR393W																																																																																																						
+YPL281C																																																																																																						
+YBR241C																																																																																																						
+YGL104C																																																																																																						
+YCL047C																																																																																																						
+YER141W									0.40																																																																																													
+YHL012W																																																																																																						
+YFL060C																																																																																																						
+YDR231C																																																																																																						
+YGR062C																																																																																																						
+YHR116W																																																																																																						
+YJL003W																																																																																																						
+YLL018C-A																																																																																																						
+YPL132W																																																																																																						
+YDR387C																																																																																																						
+YCR068W																																																																																																						
+YAL035W																																																																																																						
+YLL001W																																																																																																						
+YNL036W										0.40		0.40	0.40	0.40	0.40		0.40		0.40				0.40						0.40												0.40																0.40	0.40						0.40			0.40	0.40	0.40					0.40				0.40	0.40					0.40		0.40	0.40						0.40					0.40	0.40		0.40	0.40
+YMR306W																																																																																																						
+YFL054C																																																																																																						
+YDR105C																																																																																																						
+YDR456W																																																																																																						
+YBR001C																																																																																																						
+YDL024C																																																																																																						
+YDL246C																																																																																																						
+YDR242W																																																																																																						
+YDR441C																																																																			0.00																																			
+YJL200C																																																																																							0.00											0.00				
+YOR283W																																																																																																						
+YGR043C																																																																																																						
+YLR164W																																																																																																						
+YNL334C																																																																																																						
+YAL039C																																																																																																						
+YKL087C																																																																																																						
+YAL061W																																																																																																						
+YBL080C																																																																																																						
+YBL091C																																																																																																						
+YLR244C																																																																																																						
+YBR022W																																																																																																						
+YMR087W																																																																																																						
+YBR046C																																																																																																						
+YBR070C																																																																																																						
+YGL047W																																																																																																						
+YBR111C																																																																																																						
+YBR147W																																																																																																						
+YDR352W																																																																																																						
+YBR222C																																																																																																						
+YBR229C																																																																																																						
+YBR235W																																																																																																						
+YBR243C																																																																																																						
+YBR281C																																					0.00																																																																	
+YNL191W																																					0.00																																																																	
+YBR295W																																																																																																						
+YCL017C																																																																																																						
+YCR011C																																																																																																						
+YCR107W																																																																																																						
+YDL243C																																																																																																						
+YJR155W																																																																																																						
+YNL331C																																																																																																						
+YOL165C																																																																																																						
+YPL088W																																																																																																						
+YEL031W																																																																																																						
+YEL070W																																																																																																						
+YNR073C																																																																																																						
+YER010C																																																																																																						
+YER042W																																																																																																						
+YER087W																																																																																																						
+YER163C																																					0.00																																																																	
+YHL018W																																																																																																						
+YHR008C																																																																																																						
+YHR043C																																																																																																						
+YHR044C																																																																																																						
+YHR109W																																																																																																						
+YDR440W																																																																																																						
+YHR119W																																																																																																						
+YJL168C																																																																																																						
+YIL023C																																																																																																						
+YMR243C																																																																																																						
+YOR316C																																																																																																						
+YIL043C																																																																																																						
+YML125C																																																																																																						
+YKL150W																																																																																																						
+YIR036C																																																																																																						
+YIR038C																																																																																																						
+YKR076W																																																																																																						
+YMR251W																																																																																																						
+YLL060C																																																																																																						
+YKL069W																																																																																							0.40											0.40				
+YKL103C																																																																																																						
+YKL215C																																																																																																						
+YKL218C																																																																																																						
+YGR154C																																																																																																						
+YFL061W																																																																																																						
+YNL335W																																																																																																						
+YFL059W																																																																																																						
+YNL333W																																																																																																						
+YFR044C																																																																																																						
+YDL120W																																																																																																						
+YDL219W																																																																																																						
+YDL236W																																																																																																						
+YDR009W																																																																																																						
+YDR036C																																																																																																						
+YDR038C																																																																																																						
+YDR039C																																																																																																						
+YDR040C																																																																																																						
+YDR051C																																																																																																						
+YOL075C																																																																																																						
+YDR111C																																																																																																						
+YDR248C																																																																																																						
+YDR410C																																																																																																						
+YDR437W																																																																																																						
+YGR216C																																																																																																						
+YNL038W																																																																																																						
+YPL076W																																																																																																						
+YPL096C-A																																																																																																						
+YPL175W																																																																																																						
+YDR516C																																1.00																												1.00																																										
+YDR533C																																																																																																						
+YMR322C																																																																																																						
+YOR391C																																																																																																						
+YPL280W																																																																																																						
+YGL006W																																																																																																						
+YGL167C																																																																																																						
+YGL017W																																																																																																						
+YGL022W																																																																																																						
+YGL027C																																																																																																						
+YGL038C																																																																																																						
+YGL065C																																																																																																						
+YGL156W																																																																																																						
+YGL169W																																																																																																						
+YGL196W																																																																																																						
+YGR012W																																																																																																						
+YGR036C																																																																																																						
+YGR046W																																																																																																						
+YGR144W																																																																																																						
+YGR227W																																																																																																						
+YGR234W																																																																																																						
+YJL046W																																																																																																						
+YJL126W																																																																																																						
+YJR040W																																																																																																						
+YJR051W																																																																																																						
+YJR104C																																																																																																						
+YJR131W																																																																																																						
+YLR057W																																																																																																						
+YJR149W																																																																																																						
+YKL220C																																																																																																						
+YLR047C																																																																																																						
+YLR214W																																																																																																						
+YNR060W																																																																																																						
+YOL152W																																																																																																						
+YOR381W																																																																																																						
+YOR384W																																																																																																						
+YLL051C																																																																																																						
+YLR099C																																																																																																						
+YPR139C																																																																																																						
+YLR143W																																																																																																						
+YLR151C																																																																																																						
+YLR239C																																																																																																						
+YMR099C																																																																																																						
+YMR162C																																																																																																						
+YMR210W																																																																																																						
+YNL048W																																																																																																						
+YNL092W																																																																																																						
+YNL219C																																																																																																						
+YNL274C																																																																																																						
+YNR030W																																																																																																						
+YOL157C																																																																																																						
+YOR002W																																																																																																						
+YOR067C																																																																																																						
+YOR149C																																																																																																						
+YOR196C																																																																																																						
+YOR226C																																																																																																						
+YPL135W																																																																																																						
+YOR251C																																																																																																						
+YOR285W																																																																																																						
+YOR286W																																																																																																						
+YOR334W																																																																																																						
+YPL060W																																																																																																						
+YPL227C																																																																																																						
+YPR003C																																																																																																						
+YPR127W																																																																																																						
+YDR371W																																																																																																						
+YLR286C																																																																																																						
+YOR161C																																																																																																						
+YDR452W																																																																																																						
+YHR201C																																																																																																						
+YDR270W																																																																																																						
+YLR351C																																																																																																						
+YMR301C																																																																																																						
+YEL004W																																																																																																						
+YEL066W																																																																																																						
+YOL122C																																																																																																						
+YNL275W																																																																																																						
+YGL255W																																																																																																						
+YLR130C																																																																																																						
+YOL130W																																																																																																						
+YNL065W																																																																																																						
+YKR093W																																																																																																						
+YDR093W																																																																																																						
+YOR306C																																																																																																						
+YPR011C																																																																																																						
+YLL053C																																																																																																						
+YJL133W																																																																																																						
+YKR052C																																																																																																						
+YPR058W																																																																																																						
+YIL048W																																																																																																						
+YAL026C																																																																																																						


### PR DESCRIPTION
This branch will:
- Update instructions on how to add new data overlay datasets
- Add a new data overlay dataset for Yeast GEM

To test:
- Read documentation and make sure it makes sense
- Use dataset in MetAtlas by `build-stack && start-stack`